### PR TITLE
Creation of fork watchtower

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3608,7 +3608,6 @@ dependencies = [
  "rift-core",
  "rift-program",
  "rift-sdk",
- "scopeguard",
  "serde",
  "serde_json",
  "sol-bindings",
@@ -3617,7 +3616,6 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
- "uuid 1.16.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2548,6 +2548,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2971,6 +2977,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "funty"
@@ -3574,6 +3586,7 @@ version = "0.1.0"
 dependencies = [
  "accumulators",
  "alloy",
+ "backoff",
  "bitcoin",
  "bitcoin-core-rs",
  "bitcoin-data-engine",
@@ -3590,17 +3603,21 @@ dependencies = [
  "futures",
  "futures-util",
  "hex",
+ "metrics",
  "reqwest 0.12.15",
  "rift-core",
  "rift-program",
  "rift-sdk",
+ "scopeguard",
  "serde",
  "serde_json",
  "sol-bindings",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "uuid 1.16.0",
 ]
 
 [[package]]
@@ -3893,6 +3910,7 @@ dependencies = [
  "hex",
  "hypernode",
  "log",
+ "mockall",
  "once_cell",
  "rift-core",
  "rift-sdk",
@@ -4281,6 +4299,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d97bbf43eb4f088f8ca469930cde17fa036207c9a5e02ccc5107c4e8b17c964"
 
 [[package]]
+name = "metrics"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25dea7ac8057892855ec285c440160265225438c3c45072613c25a4b26e98ef5"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4324,6 +4352,32 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "mockall"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -5154,6 +5208,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy 0.8.24",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -7653,6 +7733,12 @@ dependencies = [
  "rustversion",
  "winapi",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-data-utils"

--- a/bin/hypernode/Cargo.toml
+++ b/bin/hypernode/Cargo.toml
@@ -38,3 +38,8 @@ chrono = { workspace = true }
 serde = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+backoff.workspace = true
+metrics = "0.24.2"
+scopeguard = "1.2.0"
+thiserror.workspace = true
+uuid = "1.16.0"

--- a/bin/hypernode/Cargo.toml
+++ b/bin/hypernode/Cargo.toml
@@ -40,6 +40,4 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 backoff.workspace = true
 metrics = "0.24.2"
-scopeguard = "1.2.0"
 thiserror.workspace = true
-uuid = "1.16.0"

--- a/bin/hypernode/src/fork_watchtower.rs
+++ b/bin/hypernode/src/fork_watchtower.rs
@@ -1,0 +1,785 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use alloy::primitives::{Address, FixedBytes};
+use alloy::providers::DynProvider;
+use backoff::backoff::Backoff;
+use backoff::exponential::ExponentialBackoff;
+use bitcoin_data_engine::BitcoinDataEngine;
+use bitcoin_light_client_core::{hasher::Keccak256Hasher, leaves::BlockLeaf, ChainTransition};
+use bitcoincore_rpc_async::bitcoin::hashes::Hash;
+use bitcoincore_rpc_async::RpcApi;
+use data_engine::engine::ContractDataEngine;
+use metrics::{counter, gauge, histogram};
+use rift_core::giga::{RiftProgramInput, RustProofType};
+use rift_sdk::bitcoin_utils::AsyncBitcoinClient;
+use rift_sdk::proof_generator::{Proof, RiftProofGenerator};
+use scopeguard::defer;
+use sol_bindings::{BlockProofParams, RiftExchangeHarnessInstance};
+use thiserror::Error;
+use tokio::sync::{broadcast, mpsc, Mutex, RwLockReadGuard};
+use tokio::task::JoinSet;
+use tokio::time;
+use tracing::{error, info, info_span, warn, Instrument};
+
+use crate::swap_watchtower::build_chain_transition_for_light_client_update;
+use crate::txn_broadcast::{
+    PreflightCheck, RevertInfo, TransactionBroadcaster, TransactionExecutionResult,
+    TransactionStatusUpdate,
+};
+
+const TRANSACTION_BROADCAST_RETRY_MAX: usize = 5;
+
+#[derive(Debug, Error)]
+pub enum ForkWatchtowerError {
+    #[error("Failed to update light client: {0}")]
+    LightClientUpdateError(String),
+
+    #[error("Failed to detect fork: {0}")]
+    ForkDetectionError(String),
+
+    #[error("Failed to generate proof: {0}")]
+    ProofGenerationError(String),
+
+    #[error("Timeout while generating proof")]
+    ProofGenerationTimeout,
+
+    #[error("Failed to broadcast transaction: {0}")]
+    TransactionBroadcastError(String),
+
+    #[error("Failed to build chain transition: {0}")]
+    ChainTransitionBuildError(String),
+
+    #[error("Transaction reverted: {0}")]
+    TransactionReverted(String),
+
+    #[error("Unknown error: {0}")]
+    Unknown(String),
+}
+
+impl From<eyre::Report> for ForkWatchtowerError {
+    fn from(err: eyre::Report) -> Self {
+        ForkWatchtowerError::Unknown(err.to_string())
+    }
+}
+
+impl From<bitcoin::hashes::FromSliceError> for ForkWatchtowerError {
+    fn from(err: bitcoin::hashes::FromSliceError) -> Self {
+        ForkWatchtowerError::ForkDetectionError(format!("Failed to create block hash: {}", err))
+    }
+}
+
+#[derive(Debug)]
+pub enum ForkDetectionResult {
+    NoFork,
+    StaleChain,
+    ForkDetected(ChainTransition),
+}
+
+#[derive(Debug)]
+enum ForkWatchtowerEvent {
+    NewTip(BlockLeaf),
+    TransactionStatus(TransactionStatusUpdate),
+    CheckForFork,
+    MmrRootUpdated([u8; 32]),
+}
+
+#[derive(Debug)]
+struct PendingForkResolution {
+    chain_transition: ChainTransition,
+    expected_mmr_root: [u8; 32],
+    transaction_hash: Option<FixedBytes<32>>,
+    retries: usize,
+}
+
+pub struct ForkWatchtower;
+
+impl ForkWatchtower {
+    pub fn run(
+        contract_data_engine: Arc<ContractDataEngine>,
+        bitcoin_data_engine: Arc<BitcoinDataEngine>,
+        btc_rpc: Arc<AsyncBitcoinClient>,
+        evm_rpc: DynProvider,
+        rift_exchange_address: Address,
+        transaction_broadcaster: Arc<TransactionBroadcaster>,
+        bitcoin_concurrency_limit: usize,
+        proof_generator: Arc<RiftProofGenerator>,
+        join_set: &mut JoinSet<eyre::Result<()>>,
+    ) {
+        join_set.spawn(
+            async move {
+                Self::event_driven_fork_watcher(
+                    contract_data_engine,
+                    bitcoin_data_engine,
+                    btc_rpc,
+                    evm_rpc,
+                    rift_exchange_address,
+                    transaction_broadcaster,
+                    bitcoin_concurrency_limit,
+                    proof_generator,
+                )
+                .await
+            }
+            .instrument(info_span!("Fork Watchtower")),
+        );
+    }
+
+    async fn event_driven_fork_watcher(
+        contract_data_engine: Arc<ContractDataEngine>,
+        bitcoin_data_engine: Arc<BitcoinDataEngine>,
+        btc_rpc: Arc<AsyncBitcoinClient>,
+        evm_rpc: DynProvider,
+        rift_exchange_address: Address,
+        transaction_broadcaster: Arc<TransactionBroadcaster>,
+        bitcoin_concurrency_limit: usize,
+        proof_generator: Arc<RiftProofGenerator>,
+    ) -> eyre::Result<()> {
+        info!("Starting tip-based fork watchtower");
+
+        counter!("fork_watchtower.started").increment(1);
+        gauge!("fork_watchtower.running").set(1.0);
+
+        defer! {
+            gauge!("fork_watchtower.running").set(0.0);
+        }
+
+        let (event_sender, mut event_receiver) = mpsc::channel::<ForkWatchtowerEvent>(10);
+
+        let rift_exchange =
+            RiftExchangeHarnessInstance::new(rift_exchange_address, evm_rpc.clone());
+
+        let mut pending_resolution: Option<PendingForkResolution> = None;
+
+        let mut block_subscription = bitcoin_data_engine.subscribe_to_new_blocks();
+        let event_sender_block = event_sender.clone();
+        
+        tokio::spawn(async move {
+            loop {
+                match block_subscription.recv().await {
+                    Ok(block) => {
+                        if event_sender_block
+                            .send(ForkWatchtowerEvent::NewTip(block))
+                            .await
+                            .is_err()
+                        {
+                            error!("Failed to forward tip event, channel closed");
+                            break;
+                        }
+                        
+                        if event_sender_block
+                            .send(ForkWatchtowerEvent::CheckForFork)
+                            .await
+                            .is_err()
+                        {
+                            error!("Failed to send check for fork event, channel closed");
+                            break;
+                        }
+                    }
+                    Err(e) => {
+                        error!("Error receiving block: {}", e);
+                        time::sleep(Duration::from_secs(1)).await;
+                    }
+                }
+            }
+        });
+
+        let mut tx_status_subscription = transaction_broadcaster.subscribe_to_status_updates();
+        let event_sender_tx = event_sender.clone();
+
+        let tx_broadcaster_clone = Arc::clone(&transaction_broadcaster);
+        tokio::spawn(async move {
+            loop {
+                match tx_status_subscription.recv().await {
+                    Ok(status) => {
+                        if event_sender_tx
+                            .send(ForkWatchtowerEvent::TransactionStatus(status))
+                            .await
+                            .is_err()
+                        {
+                            error!("Failed to forward transaction status event, channel closed");
+                            break;
+                        }
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                        error!(
+                            "Transaction status subscription lagged, missed {} messages",
+                            n
+                        );
+                        tx_status_subscription = tx_broadcaster_clone.subscribe_to_status_updates();
+                    }
+                    Err(e) => {
+                        error!("Error receiving transaction status: {}", e);
+                        break;
+                    }
+                }
+            }
+        });
+
+        let mut mmr_root_subscription = contract_data_engine.subscribe_to_mmr_root_updates();
+        let event_sender_mmr = event_sender.clone();
+
+        let mmr_root_subscription_cde = Arc::clone(&contract_data_engine);
+        tokio::spawn(async move {
+            loop {
+                match mmr_root_subscription.recv().await {
+                    Ok(root) => {
+                        if event_sender_mmr
+                            .send(ForkWatchtowerEvent::MmrRootUpdated(root))
+                            .await
+                            .is_err()
+                        {
+                            error!("Failed to forward MMR root update event, channel closed");
+                            break;
+                        }
+                        
+                        if event_sender_mmr
+                            .send(ForkWatchtowerEvent::CheckForFork)
+                            .await
+                            .is_err()
+                        {
+                            error!("Failed to send check for fork event, channel closed");
+                            break;
+                        }
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                        error!("MMR root subscription lagged, missed {} messages", n);
+                        mmr_root_subscription =
+                            mmr_root_subscription_cde.subscribe_to_mmr_root_updates();
+                    }
+                    Err(e) => {
+                        error!("Error receiving MMR root update: {}", e);
+                        break;
+                    }
+                }
+            }
+        });
+
+        let fork_detection_lock = Arc::new(Mutex::new(()));
+
+        while let Some(event) = event_receiver.recv().await {
+            match event {
+                ForkWatchtowerEvent::NewTip(_) | ForkWatchtowerEvent::CheckForFork => {
+                    if pending_resolution.is_none() {
+                        let _lock = fork_detection_lock.lock().await;
+
+                        let start = time::Instant::now();
+                        match Self::detect_fork(
+                            &contract_data_engine,
+                            &bitcoin_data_engine,
+                            &btc_rpc,
+                            bitcoin_concurrency_limit,
+                        )
+                        .await
+                        {
+                            Ok(ForkDetectionResult::ForkDetected(chain_transition)) => {
+                                info!("Fork detected, generating proof");
+                                counter!("fork_watchtower.fork_detected").increment(1);
+                                histogram!("fork_watchtower.detection_time")
+                                    .record(start.elapsed().as_secs_f64());
+
+                                Self::handle_fork_resolution(
+                                    chain_transition,
+                                    &proof_generator,
+                                    &rift_exchange,
+                                    &transaction_broadcaster,
+                                    &mut pending_resolution,
+                                )
+                                .await;
+                            }
+                            Ok(ForkDetectionResult::NoFork) => {
+                                info!("No fork detected at tip");
+                                counter!("fork_watchtower.no_fork_detected").increment(1);
+                            }
+                            Ok(ForkDetectionResult::StaleChain) => {
+                                info!(
+                                    "Light client chain is stale but valid (included in BDE chain)"
+                                );
+                                counter!("fork_watchtower.stale_chain_detected").increment(1);
+                            }
+                            Err(e) => {
+                                error!("Error detecting fork: {}", e);
+                                counter!("fork_watchtower.fork_detection_error").increment(1);
+                            }
+                        }
+                    }
+                }
+
+                ForkWatchtowerEvent::MmrRootUpdated(root) => {
+                    info!("Received MMR root update event: {}", hex::encode(root));
+                    counter!("fork_watchtower.mmr_root_updated").increment(1);
+
+                    if let Some(resolution) = &pending_resolution {
+                        if resolution.expected_mmr_root == root {
+                            info!("MMR root update confirmed our fork resolution");
+                            counter!("fork_watchtower.resolution_confirmed").increment(1);
+                            pending_resolution = None;
+                        }
+                    }
+                }
+
+                ForkWatchtowerEvent::TransactionStatus(status) => {
+                    if let Some(resolution) = &mut pending_resolution {
+                        if let Some(tx_hash) = &resolution.transaction_hash {
+                            if status.tx_hash == *tx_hash {
+                                info!("Received status update for our fork resolution transaction");
+
+                                match status.result {
+                                    TransactionExecutionResult::Success(receipt) => {
+                                        info!(
+                                            "Fork resolution transaction successful: {:?}",
+                                            receipt
+                                        );
+                                        counter!("fork_watchtower.transaction_broadcast_success")
+                                            .increment(1);
+
+                                    }
+                                    TransactionExecutionResult::Revert(revert_info) => {
+                                        let should_retry = Self::handle_transaction_revert(
+                                            &revert_info,
+                                            resolution.expected_mmr_root,
+                                        );
+
+                                        if should_retry
+                                            && resolution.retries < TRANSACTION_BROADCAST_RETRY_MAX
+                                        {
+                                            resolution.retries += 1;
+                                            resolution.transaction_hash = None;
+
+                                            warn!(
+                                                "Transaction reverted with recoverable error, will retry ({}/{})",
+                                                resolution.retries, TRANSACTION_BROADCAST_RETRY_MAX
+                                            );
+                                            counter!("fork_watchtower.transaction_broadcast_retry")
+                                                .increment(1);
+
+                                            Self::handle_fork_resolution(
+                                                resolution.chain_transition.clone(),
+                                                &proof_generator,
+                                                &rift_exchange,
+                                                &transaction_broadcaster,
+                                                &mut pending_resolution,
+                                            )
+                                            .await;
+                                        } else {
+                                            error!("Transaction reverted with unrecoverable error: {:?}", revert_info);
+                                            counter!("fork_watchtower.transaction_broadcast_unrecoverable_error").increment(1);
+                                            pending_resolution = None;
+                                        }
+                                    }
+                                    TransactionExecutionResult::InvalidRequest(msg) => {
+                                        error!("Invalid transaction request: {}", msg);
+                                        counter!(
+                                            "fork_watchtower.transaction_broadcast_invalid_request"
+                                        )
+                                        .increment(1);
+                                        pending_resolution = None;
+                                    }
+                                    TransactionExecutionResult::UnknownError(msg) => {
+                                        if resolution.retries < TRANSACTION_BROADCAST_RETRY_MAX {
+                                            resolution.retries += 1;
+                                            resolution.transaction_hash = None;
+
+                                            warn!(
+                                                "Transaction failed with unknown error, will retry ({}/{}): {}",
+                                                resolution.retries, TRANSACTION_BROADCAST_RETRY_MAX, msg
+                                            );
+                                            counter!("fork_watchtower.transaction_broadcast_unknown_error").increment(1);
+
+                                            Self::handle_fork_resolution(
+                                                resolution.chain_transition.clone(),
+                                                &proof_generator,
+                                                &rift_exchange,
+                                                &transaction_broadcaster,
+                                                &mut pending_resolution,
+                                            )
+                                            .await;
+                                        } else {
+                                            error!("Max retries reached for transaction broadcast");
+                                            counter!("fork_watchtower.max_retries_reached")
+                                                .increment(1);
+                                            pending_resolution = None;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        error!("Event channel closed unexpectedly");
+        Err(eyre::eyre!("Event channel closed"))
+    }
+
+    pub async fn handle_fork_resolution(
+        chain_transition: ChainTransition,
+        proof_generator: &Arc<RiftProofGenerator>,
+        rift_exchange: &RiftExchangeHarnessInstance<DynProvider>,
+        transaction_broadcaster: &Arc<TransactionBroadcaster>,
+        pending_resolution: &mut Option<PendingForkResolution>,
+    ) {
+        match Self::generate_light_client_update_proof(
+            chain_transition.clone(),
+            Arc::clone(proof_generator),
+        )
+        .await
+        {
+            Ok(proof) => {
+                info!("Generated proof for fork resolution");
+
+                let (public_values, auxiliary_data) = {
+                    let rift_program_input = RiftProgramInput::builder()
+                        .proof_type(RustProofType::LightClientOnly)
+                        .light_client_input(chain_transition.clone())
+                        .build()
+                        .map_err(|e| {
+                            error!("Failed to build program input: {}", e);
+                            return;
+                        })
+                        .unwrap();
+
+                    rift_program_input.get_auxiliary_light_client_data()
+                };
+
+                let block_proof_params = BlockProofParams {
+                    priorMmrRoot: public_values.priorMmrRoot,
+                    newMmrRoot: public_values.newMmrRoot,
+                    tipBlockLeaf: public_values.tipBlockLeaf,
+                    compressedBlockLeaves: auxiliary_data.compressed_leaves.into(),
+                };
+
+                let proof_bytes = match &proof.proof {
+                    Some(p) => p.bytes(),
+                    None => {
+                        warn!("Using mock proof for light client update");
+                        counter!("fork_watchtower.mock_proof_generated").increment(1);
+                        Vec::new()
+                    }
+                };
+
+                let call =
+                    rift_exchange.updateLightClient(block_proof_params.clone(), proof_bytes.into());
+                let calldata = call.calldata().to_owned();
+                let transaction_request = call.into_transaction_request();
+
+                info!("Broadcasting fork resolution transaction");
+
+                let mut new_resolution = PendingForkResolution {
+                    chain_transition,
+                    expected_mmr_root: public_values.newMmrRoot.0,
+                    transaction_hash: None,
+                    retries: 0,
+                };
+
+                match Arc::clone(transaction_broadcaster)
+                    .broadcast_transaction(calldata, transaction_request, PreflightCheck::Simulate)
+                    .await
+                {
+                    Ok(tx_result) => {
+                        if let TransactionExecutionResult::Success(receipt) = &tx_result {
+                            new_resolution.transaction_hash = Some(receipt.transaction_hash);
+                            info!("Transaction sent: {:?}", receipt.transaction_hash);
+                        }
+                        *pending_resolution = Some(new_resolution);
+                    }
+                    Err(e) => {
+                        error!("Failed to send transaction: {}", e);
+                        counter!("fork_watchtower.transaction_send_error").increment(1);
+                    }
+                }
+            }
+            Err(e) => {
+                error!("Failed to generate proof: {}", e);
+                counter!("fork_watchtower.proof_generation_error").increment(1);
+            }
+        }
+    }
+
+    pub async fn detect_fork(
+      contract_data_engine: &Arc<ContractDataEngine>,
+      bitcoin_data_engine: &Arc<BitcoinDataEngine>,
+      btc_rpc: &Arc<AsyncBitcoinClient>,
+      bitcoin_concurrency_limit: usize,
+  ) -> Result<ForkDetectionResult, ForkWatchtowerError> {
+      info!("Checking for fork at chain tips only");
+  
+      let light_client_mmr = contract_data_engine.checkpointed_block_tree.read().await;
+      let bitcoin_mmr = bitcoin_data_engine.indexed_mmr.read().await;
+  
+      let light_client_tip_index = light_client_mmr.get_leaf_count().await.map_err(|e| {
+          ForkWatchtowerError::ForkDetectionError(format!(
+              "Failed to get light client leaf count: {}",
+              e
+          ))
+      })? - 1;
+  
+      let light_client_tip_leaf = light_client_mmr
+          .get_leaf_by_leaf_index(light_client_tip_index)
+          .await
+          .map_err(|e| {
+              ForkWatchtowerError::ForkDetectionError(format!(
+                  "Failed to get light client tip leaf: {}",
+                  e
+              ))
+          })?
+          .ok_or_else(|| {
+              ForkWatchtowerError::ForkDetectionError(
+                  "Light client tip leaf not found".to_string(),
+              )
+          })?;
+  
+      let bitcoin_tip_index = bitcoin_mmr.get_leaf_count().await.map_err(|e| {
+          ForkWatchtowerError::ForkDetectionError(format!(
+              "Failed to get bitcoin leaf count: {}",
+              e
+          ))
+      })? - 1;
+  
+      let bitcoin_tip_leaf = bitcoin_mmr
+          .get_leaf_by_leaf_index(bitcoin_tip_index)
+          .await
+          .map_err(|e| {
+              ForkWatchtowerError::ForkDetectionError(format!(
+                  "Failed to get bitcoin tip leaf: {}",
+                  e
+              ))
+          })?
+          .ok_or_else(|| {
+              ForkWatchtowerError::ForkDetectionError("Bitcoin tip leaf not found".to_string())
+          })?;
+  
+      if light_client_tip_leaf.block_hash == bitcoin_tip_leaf.block_hash {
+          info!(
+              message = "No fork - tips match exactly",
+              tip_hash = hex::encode(light_client_tip_leaf.block_hash),
+          );
+          return Ok(ForkDetectionResult::NoFork);
+      }
+  
+      let light_client_chainwork = light_client_tip_leaf.chainwork_as_u256();
+      let bitcoin_chainwork = bitcoin_tip_leaf.chainwork_as_u256();
+  
+      if light_client_chainwork == bitcoin_chainwork {
+          info!(
+              message = "Tips have equal chainwork, following first-seen policy (no fork)",
+              chainwork = format!("{:x}", light_client_chainwork),
+          );
+          return Ok(ForkDetectionResult::NoFork);
+      }
+  
+      let is_included =
+          Self::check_leaf_inclusion_in_bde(&light_client_tip_leaf, &bitcoin_mmr, btc_rpc)
+              .await?;
+  
+      if is_included {
+          info!(
+              message = "Light client tip is included in BDE chain, no fork needed",
+              light_client_tip = hex::encode(light_client_tip_leaf.block_hash),
+          );
+          return Ok(ForkDetectionResult::StaleChain);
+      }
+
+      if light_client_chainwork > bitcoin_chainwork {
+          info!(
+              message = "Fork detected - light client has block not in BDE chain with higher chainwork",
+              light_client_tip = hex::encode(light_client_tip_leaf.block_hash),
+              light_client_chainwork = format!("{:x}", light_client_chainwork),
+              bitcoin_chainwork = format!("{:x}", bitcoin_chainwork),
+          );
+      } else {
+          info!(
+              message = "Fork detected - light client tip not in BDE chain and BDE has more chainwork",
+              light_client_tip = hex::encode(light_client_tip_leaf.block_hash),
+              light_client_chainwork = format!("{:x}", light_client_chainwork),
+              bitcoin_chainwork = format!("{:x}", bitcoin_chainwork),
+          );
+      }
+  
+      let chain_transition = build_chain_transition_for_light_client_update(
+          Arc::clone(btc_rpc),
+          &bitcoin_mmr,
+          &light_client_mmr,
+          bitcoin_concurrency_limit,
+      )
+      .await
+      .map_err(|e| ForkWatchtowerError::ChainTransitionBuildError(e.to_string()))?;
+  
+      Ok(ForkDetectionResult::ForkDetected(chain_transition))
+  }
+
+    pub async fn check_leaf_inclusion_in_bde(
+        leaf: &BlockLeaf,
+        bitcoin_mmr: &RwLockReadGuard<'_, rift_sdk::indexed_mmr::IndexedMMR<Keccak256Hasher>>,
+        btc_rpc: &Arc<AsyncBitcoinClient>,
+    ) -> Result<bool, ForkWatchtowerError> {
+        let leaf_hash = leaf.hash::<Keccak256Hasher>();
+        let leaf_result = bitcoin_mmr
+            .get_leaf_by_leaf_hash(&leaf_hash)
+            .await
+            .map_err(|e| {
+                ForkWatchtowerError::ForkDetectionError(format!(
+                    "Failed to query leaf in BDE: {}",
+                    e
+                ))
+            })?;
+
+        if leaf_result.is_some() {
+            info!(
+                "Leaf found directly in BDE MMR: height={}, hash={}",
+                leaf.height,
+                hex::encode(leaf.block_hash)
+            );
+            return Ok(true);
+        }
+
+        let natural_block_hash = leaf.natural_block_hash();
+
+        info!(
+            "Checking if block exists in Bitcoin chain: height={}, hash={}",
+            leaf.height,
+            hex::encode(natural_block_hash)
+        );
+
+        let block_header_result = btc_rpc
+            .get_block_header_info(&bitcoincore_rpc_async::bitcoin::BlockHash::from_slice(
+                &natural_block_hash,
+            )?)
+            .await;
+
+        match block_header_result { 
+            Ok(header_info) => {
+                let block_height = header_info.height as u32;
+
+                let mut is_in_main_chain =
+                    header_info.confirmations > 0 && block_height == leaf.height;
+
+                info!(
+                  "Block found in Bitcoin chain: confirmations={}, chain height={}, block height={}, expected height={}",
+                  header_info.confirmations, block_height, block_height, leaf.height
+              );
+
+                if is_in_main_chain {
+                    if let Ok(height_hash) = btc_rpc.get_block_hash(block_height as u64).await {
+                        let height_hash_str = height_hash.to_string();
+                        let block_hash_str = bitcoincore_rpc_async::bitcoin::BlockHash::from_slice(
+                            &natural_block_hash,
+                        )?
+                        .to_string();
+
+                        if height_hash_str != block_hash_str {
+                            info!(
+                              "Found different block at height {} in main chain. Fork detected! Main chain hash: {}, Block hash: {}",
+                              block_height, height_hash_str, block_hash_str
+                          );
+                            is_in_main_chain = false;
+                        }
+                    }
+                }
+
+                info!(
+                  "Block check result: is_in_main_chain={}, confirmations={}, height={}, expected_height={}",
+                  is_in_main_chain, header_info.confirmations, block_height, leaf.height
+              );
+
+                Ok(is_in_main_chain)
+            }
+            Err(bitcoincore_rpc_async::Error::JsonRpc(
+                bitcoincore_rpc_async::jsonrpc::error::Error::Rpc(ref rpcerr),
+            )) if rpcerr.code == -5 => {
+                info!(
+                    "Block not found in Bitcoin chain at all: height={}, hash={}",
+                    leaf.height,
+                    hex::encode(natural_block_hash)
+                );
+                Ok(false)
+            }
+            Err(e) => {
+                error!("Error checking block in Bitcoin chain: {}", e);
+                Err(ForkWatchtowerError::ForkDetectionError(format!(
+                    "Failed to query block header: {}",
+                    e
+                )))
+            }
+        }
+    }
+
+    async fn generate_light_client_update_proof(
+        chain_transition: ChainTransition,
+        proof_generator: Arc<RiftProofGenerator>,
+    ) -> Result<Proof, ForkWatchtowerError> {
+        info!(message = "Generating light client update proof");
+
+        let program_input = RiftProgramInput::builder()
+            .proof_type(RustProofType::LightClientOnly)
+            .light_client_input(chain_transition)
+            .build()
+            .map_err(|e| ForkWatchtowerError::ProofGenerationError(e.to_string()))?;
+
+        let mut backoff: backoff::exponential::ExponentialBackoff<backoff::SystemClock> =
+            ExponentialBackoff::default();
+        backoff.max_elapsed_time = Some(Duration::from_secs(300));
+
+        let proof_result = loop {
+            match proof_generator.prove(&program_input).await {
+                Ok(proof) => break Ok(proof),
+                Err(e) => {
+                    warn!("Proof generation failed, retrying: {}", e);
+                    counter!("fork_watchtower.proof_generation_retry").increment(1);
+
+                    if let Some(duration) = backoff.next_backoff() {
+                        time::sleep(duration).await;
+                    } else {
+                        break Err(ForkWatchtowerError::ProofGenerationError(e.to_string()));
+                    }
+                }
+            }
+        };
+
+        proof_result
+    }
+
+    pub fn handle_transaction_revert(
+        revert_info: &RevertInfo,
+        expected_mmr_root: [u8; 32],
+    ) -> bool {
+        info!(
+            "Analyzing transaction revert: {:?}, debug command: {}",
+            revert_info.error_payload, revert_info.debug_cli_command
+        );
+
+        let error_msg = revert_info.error_payload.message.to_lowercase();
+
+        if error_msg.contains("root already exists") || error_msg.contains("mmr root match") {
+            info!("MMR root already updated by someone else, no retry needed");
+            return false;
+        }
+
+        if error_msg.contains("nonce too low")
+            || error_msg.contains("nonce too high")
+            || error_msg.contains("replacement transaction underpriced")
+        {
+            info!("Transaction nonce issue, will retry");
+            return true;
+        }
+
+        if error_msg.contains("gas price")
+            || error_msg.contains("max fee")
+            || error_msg.contains("gas limit")
+        {
+            info!("Gas price issue, will retry");
+            return true;
+        }
+
+        if error_msg.contains("network")
+            || error_msg.contains("timeout")
+            || error_msg.contains("connection")
+        {
+            info!("Network issue, will retry");
+            return true;
+        }
+
+        info!("Unknown revert reason, will attempt retry");
+        true
+    }
+}

--- a/bin/hypernode/src/fork_watchtower.rs
+++ b/bin/hypernode/src/fork_watchtower.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 
 use alloy::primitives::{Address, FixedBytes};
 use alloy::providers::DynProvider;
+use alloy::sol_types::SolError;
 use backoff::backoff::Backoff;
 use backoff::exponential::ExponentialBackoff;
 use bitcoin_data_engine::BitcoinDataEngine;
@@ -13,10 +14,12 @@ use data_engine::engine::ContractDataEngine;
 use rift_core::giga::{RiftProgramInput, RustProofType};
 use rift_sdk::bitcoin_utils::AsyncBitcoinClient;
 use rift_sdk::proof_generator::{Proof, RiftProofGenerator};
-use scopeguard::defer;
-use sol_bindings::{BlockProofParams, RiftExchangeHarnessInstance};
+use sol_bindings::{
+    BlockNotConfirmed, BlockNotInChain, BlockProofParams, ChainworkTooLow,
+    CheckpointNotEstablished, RiftExchangeHarnessInstance,
+};
 use thiserror::Error;
-use tokio::sync::{broadcast, mpsc, Mutex, RwLockReadGuard};
+use tokio::sync::{mpsc, Mutex, RwLockReadGuard};
 use tokio::task::JoinSet;
 use tokio::time;
 use tracing::{error, info, info_span, warn, Instrument};
@@ -24,7 +27,6 @@ use tracing::{error, info, info_span, warn, Instrument};
 use crate::swap_watchtower::build_chain_transition_for_light_client_update;
 use crate::txn_broadcast::{
     PreflightCheck, RevertInfo, TransactionBroadcaster, TransactionExecutionResult,
-    TransactionStatusUpdate,
 };
 
 const TRANSACTION_BROADCAST_RETRY_MAX: usize = 5;
@@ -78,23 +80,14 @@ pub enum ForkDetectionResult {
 #[derive(Debug)]
 enum ForkWatchtowerEvent {
     NewTip(BlockLeaf),
-    TransactionStatus(TransactionStatusUpdate),
     CheckForFork,
     MmrRootUpdated([u8; 32]),
-}
-
-#[derive(Debug)]
-struct PendingForkResolution {
-    chain_transition: ChainTransition,
-    expected_mmr_root: [u8; 32],
-    transaction_hash: Option<FixedBytes<32>>,
-    retries: usize,
 }
 
 pub struct ForkWatchtower;
 
 impl ForkWatchtower {
-    pub fn run(
+    pub async fn run(
         contract_data_engine: Arc<ContractDataEngine>,
         bitcoin_data_engine: Arc<BitcoinDataEngine>,
         btc_rpc: Arc<AsyncBitcoinClient>,
@@ -104,35 +97,7 @@ impl ForkWatchtower {
         bitcoin_concurrency_limit: usize,
         proof_generator: Arc<RiftProofGenerator>,
         join_set: &mut JoinSet<eyre::Result<()>>,
-    ) {
-        join_set.spawn(
-            async move {
-                Self::event_driven_fork_watcher(
-                    contract_data_engine,
-                    bitcoin_data_engine,
-                    btc_rpc,
-                    evm_rpc,
-                    rift_exchange_address,
-                    transaction_broadcaster,
-                    bitcoin_concurrency_limit,
-                    proof_generator,
-                )
-                .await
-            }
-            .instrument(info_span!("Fork Watchtower")),
-        );
-    }
-
-    async fn event_driven_fork_watcher(
-        contract_data_engine: Arc<ContractDataEngine>,
-        bitcoin_data_engine: Arc<BitcoinDataEngine>,
-        btc_rpc: Arc<AsyncBitcoinClient>,
-        evm_rpc: DynProvider,
-        rift_exchange_address: Address,
-        transaction_broadcaster: Arc<TransactionBroadcaster>,
-        bitcoin_concurrency_limit: usize,
-        proof_generator: Arc<RiftProofGenerator>,
-    ) -> eyre::Result<()> {
+    ) -> eyre::Result<Self> {
         info!("Starting fork watchtower");
 
         let (event_sender, mut event_receiver) = mpsc::channel::<ForkWatchtowerEvent>(10);
@@ -140,121 +105,98 @@ impl ForkWatchtower {
         let rift_exchange =
             RiftExchangeHarnessInstance::new(rift_exchange_address, evm_rpc.clone());
 
-        let mut pending_resolution: Option<PendingForkResolution> = None;
+        let fork_in_progress = Arc::new(std::sync::atomic::AtomicBool::new(false));
 
         let mut block_subscription = bitcoin_data_engine.subscribe_to_new_blocks();
         let event_sender_block = event_sender.clone();
-        
-        tokio::spawn(async move {
-            loop {
-                match block_subscription.recv().await {
-                    Ok(block) => {
-                        if event_sender_block
-                            .send(ForkWatchtowerEvent::NewTip(block))
-                            .await
-                            .is_err()
-                        {
-                            error!("Failed to forward event channel closed");
-                            break;
+
+        join_set.spawn(
+            async move {
+                loop {
+                    match block_subscription.recv().await {
+                        Ok(block) => {
+                            if event_sender_block
+                                .send(ForkWatchtowerEvent::NewTip(block))
+                                .await
+                                .is_err()
+                            {
+                                error!("Failed to forward event channel closed");
+                                break;
+                            }
+
+                            if event_sender_block
+                                .send(ForkWatchtowerEvent::CheckForFork)
+                                .await
+                                .is_err()
+                            {
+                                error!("Failed to send check for fork event channel closed");
+                                break;
+                            }
                         }
-                        
-                        if event_sender_block
-                            .send(ForkWatchtowerEvent::CheckForFork)
-                            .await
-                            .is_err()
-                        {
-                            error!("Failed to send check for fork event channel closed");
-                            break;
+                        Err(e) => {
+                            error!("Error receiving block: {}", e);
+                            time::sleep(Duration::from_secs(1)).await;
                         }
-                    }
-                    Err(e) => {
-                        error!("Error receiving block: {}", e);
-                        time::sleep(Duration::from_secs(1)).await;
                     }
                 }
-            }
-        });
 
-        let mut tx_status_subscription = transaction_broadcaster.subscribe_to_status_updates();
-        let event_sender_tx = event_sender.clone();
-
-        let tx_broadcaster_clone = Arc::clone(&transaction_broadcaster);
-        tokio::spawn(async move {
-            loop {
-                match tx_status_subscription.recv().await {
-                    Ok(status) => {
-                        if event_sender_tx
-                            .send(ForkWatchtowerEvent::TransactionStatus(status))
-                            .await
-                            .is_err()
-                        {
-                            error!("Failed to forward transaction status event channel closed");
-                            break;
-                        }
-                    }
-                    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                        error!(
-                            "Transaction status subscription lagged missed {} messages",
-                            n
-                        );
-                        tx_status_subscription = tx_broadcaster_clone.subscribe_to_status_updates();
-                    }
-                    Err(e) => {
-                        error!("Error receiving transaction status: {}", e);
-                        break;
-                    }
-                }
+                Ok(())
             }
-        });
+            .instrument(info_span!("Block Subscription Handler")),
+        );
 
         let mut mmr_root_subscription = contract_data_engine.subscribe_to_mmr_root_updates();
         let event_sender_mmr = event_sender.clone();
-
         let mmr_root_subscription_cde = Arc::clone(&contract_data_engine);
-        tokio::spawn(async move {
-            loop {
-                match mmr_root_subscription.recv().await {
-                    Ok(root) => {
-                        if event_sender_mmr
-                            .send(ForkWatchtowerEvent::MmrRootUpdated(root))
-                            .await
-                            .is_err()
-                        {
-                            error!("Failed to forward MMR root update event channel closed");
+
+        join_set.spawn(
+            async move {
+                loop {
+                    match mmr_root_subscription.recv().await {
+                        Ok(root) => {
+                            if event_sender_mmr
+                                .send(ForkWatchtowerEvent::MmrRootUpdated(root))
+                                .await
+                                .is_err()
+                            {
+                                error!("Failed to forward MMR root update event channel closed");
+                                break;
+                            }
+
+                            if event_sender_mmr
+                                .send(ForkWatchtowerEvent::CheckForFork)
+                                .await
+                                .is_err()
+                            {
+                                error!("Failed to send check for fork event channel closed");
+                                break;
+                            }
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                            error!("MMR root subscription lagged, missed {} messages", n);
+                            mmr_root_subscription =
+                                mmr_root_subscription_cde.subscribe_to_mmr_root_updates();
+                        }
+                        Err(e) => {
+                            error!("Error receiving MMR root update: {}", e);
                             break;
                         }
-                        
-                        if event_sender_mmr
-                            .send(ForkWatchtowerEvent::CheckForFork)
-                            .await
-                            .is_err()
-                        {
-                            error!("Failed to send check for fork event channel closed");
-                            break;
-                        }
-                    }
-                    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                        error!("MMR root subscription lagged, missed {} messages", n);
-                        mmr_root_subscription =
-                            mmr_root_subscription_cde.subscribe_to_mmr_root_updates();
-                    }
-                    Err(e) => {
-                        error!("Error receiving MMR root update: {}", e);
-                        break;
                     }
                 }
+
+                Ok(())
             }
-        });
+            .instrument(info_span!("MMR Root Subscription Handler")),
+        );
 
         let fork_detection_lock = Arc::new(Mutex::new(()));
 
         while let Some(event) = event_receiver.recv().await {
             match event {
                 ForkWatchtowerEvent::NewTip(_) | ForkWatchtowerEvent::CheckForFork => {
-                    if pending_resolution.is_none() {
+                    if !fork_in_progress.load(std::sync::atomic::Ordering::SeqCst) {
                         let _lock = fork_detection_lock.lock().await;
 
-                        let start = time::Instant::now();
                         match Self::detect_fork(
                             &contract_data_engine,
                             &bitcoin_data_engine,
@@ -264,16 +206,32 @@ impl ForkWatchtower {
                         .await
                         {
                             Ok(ForkDetectionResult::ForkDetected(chain_transition)) => {
-                                info!("Fork detected, generating proof");
+                                info!("Fork detected, generating proof and resolving");
 
-                                Self::handle_fork_resolution(
-                                    chain_transition,
-                                    &proof_generator,
-                                    &rift_exchange,
-                                    &transaction_broadcaster,
-                                    &mut pending_resolution,
-                                )
-                                .await;
+                                fork_in_progress.store(true, std::sync::atomic::Ordering::SeqCst);
+
+                                let proof_generator_clone = proof_generator.clone();
+                                let rift_exchange_clone = rift_exchange.clone();
+                                let transaction_broadcaster_clone = transaction_broadcaster.clone();
+                                let fork_in_progress_clone = fork_in_progress.clone();
+
+                                join_set.spawn(
+                                    async move {
+                                        Self::process_fork_resolution(
+                                            chain_transition,
+                                            &proof_generator_clone,
+                                            &rift_exchange_clone,
+                                            &transaction_broadcaster_clone,
+                                        )
+                                        .await;
+
+                                        fork_in_progress_clone
+                                            .store(false, std::sync::atomic::Ordering::SeqCst);
+
+                                        Ok(())
+                                    }
+                                    .instrument(info_span!("Fork Resolution Handler")),
+                                );
                             }
                             Ok(ForkDetectionResult::NoFork) => {
                                 info!("No fork detected at tip");
@@ -292,90 +250,6 @@ impl ForkWatchtower {
 
                 ForkWatchtowerEvent::MmrRootUpdated(root) => {
                     info!("Received MMR root update event: {}", hex::encode(root));
-
-                    if let Some(resolution) = &pending_resolution {
-                        if resolution.expected_mmr_root == root {
-                            info!("MMR root update confirmed the fork resolution");
-                            pending_resolution = None;
-                        }
-                    }
-                }
-
-                ForkWatchtowerEvent::TransactionStatus(status) => {
-                    if let Some(resolution) = &mut pending_resolution {
-                        if let Some(tx_hash) = &resolution.transaction_hash {
-                            if status.tx_hash == *tx_hash {
-                                info!("Received status update for the fork resolution transaction");
-
-                                match status.result {
-                                    TransactionExecutionResult::Success(receipt) => {
-                                        info!(
-                                            "Fork resolution transaction successful: {:?}",
-                                            receipt
-                                        );
-
-                                    }
-                                    TransactionExecutionResult::Revert(revert_info) => {
-                                        let should_retry = Self::handle_transaction_revert(
-                                            &revert_info,
-                                            resolution.expected_mmr_root,
-                                        );
-
-                                        if should_retry
-                                            && resolution.retries < TRANSACTION_BROADCAST_RETRY_MAX
-                                        {
-                                            resolution.retries += 1;
-                                            resolution.transaction_hash = None;
-
-                                            warn!(
-                                                "Transaction reverted with recoverable error, retry ({}/{})",
-                                                resolution.retries, TRANSACTION_BROADCAST_RETRY_MAX
-                                            );
-
-                                            Self::handle_fork_resolution(
-                                                resolution.chain_transition.clone(),
-                                                &proof_generator,
-                                                &rift_exchange,
-                                                &transaction_broadcaster,
-                                                &mut pending_resolution,
-                                            )
-                                            .await;
-                                        } else {
-                                            error!("Transaction reverted with unrecoverable error: {:?}", revert_info);
-                                            pending_resolution = None;
-                                        }
-                                    }
-                                    TransactionExecutionResult::InvalidRequest(msg) => {
-                                        error!("Invalid transaction request: {}", msg);
-                                        pending_resolution = None;
-                                    }
-                                    TransactionExecutionResult::UnknownError(msg) => {
-                                        if resolution.retries < TRANSACTION_BROADCAST_RETRY_MAX {
-                                            resolution.retries += 1;
-                                            resolution.transaction_hash = None;
-
-                                            warn!(
-                                                "Transaction failed with unknown error, retry ({}/{}): {}",
-                                                resolution.retries, TRANSACTION_BROADCAST_RETRY_MAX, msg
-                                            );
-
-                                            Self::handle_fork_resolution(
-                                                resolution.chain_transition.clone(),
-                                                &proof_generator,
-                                                &rift_exchange,
-                                                &transaction_broadcaster,
-                                                &mut pending_resolution,
-                                            )
-                                            .await;
-                                        } else {
-                                            error!("Max retries reached for transaction broadcast");
-                                            pending_resolution = None;
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
                 }
             }
         }
@@ -384,198 +258,262 @@ impl ForkWatchtower {
         Err(eyre::eyre!("Event channel closed"))
     }
 
-    pub async fn handle_fork_resolution(
+    pub async fn process_fork_resolution(
         chain_transition: ChainTransition,
         proof_generator: &Arc<RiftProofGenerator>,
         rift_exchange: &RiftExchangeHarnessInstance<DynProvider>,
         transaction_broadcaster: &Arc<TransactionBroadcaster>,
-        pending_resolution: &mut Option<PendingForkResolution>,
     ) {
-        match Self::generate_light_client_update_proof(
+        let proof_result = Self::generate_light_client_update_proof(
             chain_transition.clone(),
             Arc::clone(proof_generator),
         )
-        .await
-        {
-            Ok(proof) => {
-                info!("Generated proof for fork resolution");
+        .await;
 
-                let (public_values, auxiliary_data) = {
-                    let rift_program_input = RiftProgramInput::builder()
-                        .proof_type(RustProofType::LightClientOnly)
-                        .light_client_input(chain_transition.clone())
-                        .build()
-                        .map_err(|e| {
-                            error!("Failed to build program input: {}", e);
-                            return;
-                        })
-                        .unwrap();
-
-                    rift_program_input.get_auxiliary_light_client_data()
-                };
-
-                let block_proof_params = BlockProofParams {
-                    priorMmrRoot: public_values.priorMmrRoot,
-                    newMmrRoot: public_values.newMmrRoot,
-                    tipBlockLeaf: public_values.tipBlockLeaf,
-                    compressedBlockLeaves: auxiliary_data.compressed_leaves.into(),
-                };
-
-                let proof_bytes = match &proof.proof {
-                    Some(p) => p.bytes(),
-                    None => {
-                        warn!("Using mock proof for light client update");
-                        Vec::new()
-                    }
-                };
-
-                let call =
-                    rift_exchange.updateLightClient(block_proof_params.clone(), proof_bytes.into());
-                let calldata = call.calldata().to_owned();
-                let transaction_request = call.into_transaction_request();
-
-                info!("Broadcasting fork resolution transaction");
-
-                let mut new_resolution = PendingForkResolution {
-                    chain_transition,
-                    expected_mmr_root: public_values.newMmrRoot.0,
-                    transaction_hash: None,
-                    retries: 0,
-                };
-
-                match Arc::clone(transaction_broadcaster)
-                    .broadcast_transaction(calldata, transaction_request, PreflightCheck::Simulate)
-                    .await
-                {
-                    Ok(tx_result) => {
-                        if let TransactionExecutionResult::Success(receipt) = &tx_result {
-                            new_resolution.transaction_hash = Some(receipt.transaction_hash);
-                            info!("Transaction sent: {:?}", receipt.transaction_hash);
-                        }
-                        *pending_resolution = Some(new_resolution);
-                    }
-                    Err(e) => {
-                        error!("Failed to send transaction: {}", e);
-                    }
-                }
-            }
+        let proof = match proof_result {
+            Ok(p) => p,
             Err(e) => {
                 error!("Failed to generate proof: {}", e);
+                return;
+            }
+        };
+
+        info!("Generated proof for fork resolution");
+
+        let (public_values, auxiliary_data) = {
+            let rift_program_input = match RiftProgramInput::builder()
+                .proof_type(RustProofType::LightClientOnly)
+                .light_client_input(chain_transition)
+                .build()
+            {
+                Ok(input) => input,
+                Err(e) => {
+                    error!("Failed to build program input: {}", e);
+                    return;
+                }
+            };
+
+            rift_program_input.get_auxiliary_light_client_data()
+        };
+
+        let block_proof_params = BlockProofParams {
+            priorMmrRoot: public_values.priorMmrRoot,
+            newMmrRoot: public_values.newMmrRoot,
+            tipBlockLeaf: public_values.tipBlockLeaf,
+            compressedBlockLeaves: auxiliary_data.compressed_leaves.into(),
+        };
+
+        let proof_bytes = match &proof.proof {
+            Some(p) => p.bytes(),
+            None => {
+                warn!("Using mock proof for light client update");
+                Vec::new()
+            }
+        };
+
+        let call = rift_exchange.updateLightClient(block_proof_params.clone(), proof_bytes.into());
+        let calldata = call.calldata().to_owned();
+        let transaction_request = call.into_transaction_request();
+
+        info!("Broadcasting fork resolution transaction");
+
+        let mut backoff: backoff::exponential::ExponentialBackoff<backoff::SystemClock> =
+            ExponentialBackoff {
+                initial_interval: Duration::from_millis(500),
+                max_interval: Duration::from_secs(10),
+                multiplier: 1.5,
+                max_elapsed_time: Some(Duration::from_secs(120)),
+                ..Default::default()
+            };
+
+        let mut retries = 0;
+        let max_retries = TRANSACTION_BROADCAST_RETRY_MAX;
+
+        loop {
+            retries += 1;
+            info!(
+                "Attempt {} of {} to broadcast fork resolution",
+                retries, max_retries
+            );
+
+            match transaction_broadcaster
+                .broadcast_transaction(
+                    calldata.clone(),
+                    transaction_request.clone(),
+                    PreflightCheck::Simulate,
+                )
+                .await
+            {
+                Ok(TransactionExecutionResult::Success(receipt)) => {
+                    info!(
+                        "Fork resolution transaction successful: {:?}",
+                        receipt.transaction_hash
+                    );
+                    return;
+                }
+                Ok(TransactionExecutionResult::Revert(revert_info)) => {
+                    let should_retry =
+                        Self::handle_transaction_revert(&revert_info);
+
+                    if !should_retry || retries >= max_retries {
+                        error!(
+                            "Transaction reverted with unrecoverable error: {:?}",
+                            revert_info
+                        );
+                        return;
+                    }
+
+                    warn!(
+                        "Transaction reverted with recoverable error, retry ({}/{})",
+                        retries, max_retries
+                    );
+                }
+                Ok(TransactionExecutionResult::InvalidRequest(msg)) => {
+                    error!("Invalid transaction request: {}", msg);
+                    return;
+                }
+                Ok(TransactionExecutionResult::UnknownError(msg)) => {
+                    if retries >= max_retries {
+                        error!("Max retries reached for transaction broadcast: {}", msg);
+                        return;
+                    }
+                    warn!(
+                        "Transaction failed with unknown error, retry ({}/{}): {}",
+                        retries, max_retries, msg
+                    );
+                }
+                Err(e) => {
+                    if retries >= max_retries {
+                        error!("Max retries reached for transaction broadcast: {}", e);
+                        return;
+                    }
+                    error!("Failed to send transaction, will retry: {}", e);
+                }
+            }
+
+            if let Some(wait_time) = backoff.next_backoff() {
+                info!("Waiting {:?} before next attempt", wait_time);
+                tokio::time::sleep(wait_time).await;
+            } else {
+                error!("Maximum backoff time exceeded");
+                return;
             }
         }
     }
 
     pub async fn detect_fork(
-      contract_data_engine: &Arc<ContractDataEngine>,
-      bitcoin_data_engine: &Arc<BitcoinDataEngine>,
-      btc_rpc: &Arc<AsyncBitcoinClient>,
-      bitcoin_concurrency_limit: usize,
-  ) -> Result<ForkDetectionResult, ForkWatchtowerError> {
-      info!("Checking for fork at chain tips only");
-  
-      let light_client_mmr = contract_data_engine.checkpointed_block_tree.read().await;
-      let bitcoin_mmr = bitcoin_data_engine.indexed_mmr.read().await;
-  
-      let light_client_tip_index = light_client_mmr.get_leaf_count().await.map_err(|e| {
-          ForkWatchtowerError::ForkDetectionError(format!(
-              "Failed to get light client leaf count: {}",
-              e
-          ))
-      })? - 1;
-  
-      let light_client_tip_leaf = light_client_mmr
-          .get_leaf_by_leaf_index(light_client_tip_index)
-          .await
-          .map_err(|e| {
-              ForkWatchtowerError::ForkDetectionError(format!(
-                  "Failed to get light client tip leaf: {}",
-                  e
-              ))
-          })?
-          .ok_or_else(|| {
-              ForkWatchtowerError::ForkDetectionError(
-                  "Light client tip leaf not found".to_string(),
-              )
-          })?;
-  
-      let bitcoin_tip_index = bitcoin_mmr.get_leaf_count().await.map_err(|e| {
-          ForkWatchtowerError::ForkDetectionError(format!(
-              "Failed to get bitcoin leaf count: {}",
-              e
-          ))
-      })? - 1;
-  
-      let bitcoin_tip_leaf = bitcoin_mmr
-          .get_leaf_by_leaf_index(bitcoin_tip_index)
-          .await
-          .map_err(|e| {
-              ForkWatchtowerError::ForkDetectionError(format!(
-                  "Failed to get bitcoin tip leaf: {}",
-                  e
-              ))
-          })?
-          .ok_or_else(|| {
-              ForkWatchtowerError::ForkDetectionError("Bitcoin tip leaf not found".to_string())
-          })?;
-  
-      if light_client_tip_leaf.block_hash == bitcoin_tip_leaf.block_hash {
-          info!(
-              message = "No fork tips match exactly",
-              tip_hash = hex::encode(light_client_tip_leaf.block_hash),
-          );
-          return Ok(ForkDetectionResult::NoFork);
-      }
-  
-      let light_client_chainwork = light_client_tip_leaf.chainwork_as_u256();
-      let bitcoin_chainwork = bitcoin_tip_leaf.chainwork_as_u256();
-  
-      if light_client_chainwork == bitcoin_chainwork {
-          info!(
-              message = "Tips have equal so first seen policy (no fork)",
-              chainwork = format!("{:x}", light_client_chainwork),
-          );
-          return Ok(ForkDetectionResult::NoFork);
-      }
-  
-      let is_included =
-          Self::check_leaf_inclusion_in_bde(&light_client_tip_leaf, &bitcoin_mmr, btc_rpc)
-              .await?;
-  
-      if is_included {
-          info!(
-              message = "Light client tip is included in BDE chain, no fork",
-              light_client_tip = hex::encode(light_client_tip_leaf.block_hash),
-          );
-          return Ok(ForkDetectionResult::StaleChain);
-      }
+        contract_data_engine: &Arc<ContractDataEngine>,
+        bitcoin_data_engine: &Arc<BitcoinDataEngine>,
+        btc_rpc: &Arc<AsyncBitcoinClient>,
+        bitcoin_concurrency_limit: usize,
+    ) -> Result<ForkDetectionResult, ForkWatchtowerError> {
+        info!("Checking for fork at chain tips only");
 
-      if light_client_chainwork > bitcoin_chainwork {
-          info!(
-              message = "Fork detected light client has block not in BDE chain with higher chainwork",
-              light_client_tip = hex::encode(light_client_tip_leaf.block_hash),
-              light_client_chainwork = format!("{:x}", light_client_chainwork),
-              bitcoin_chainwork = format!("{:x}", bitcoin_chainwork),
-          );
-      } else {
-          info!(
-              message = "Fork detected light client tip not in BDE chain and BDE has more chainwork",
-              light_client_tip = hex::encode(light_client_tip_leaf.block_hash),
-              light_client_chainwork = format!("{:x}", light_client_chainwork),
-              bitcoin_chainwork = format!("{:x}", bitcoin_chainwork),
-          );
-      }
-  
-      let chain_transition = build_chain_transition_for_light_client_update(
-          Arc::clone(btc_rpc),
-          &bitcoin_mmr,
-          &light_client_mmr,
-          bitcoin_concurrency_limit,
-      )
-      .await
-      .map_err(|e| ForkWatchtowerError::ChainTransitionBuildError(e.to_string()))?;
-  
-      Ok(ForkDetectionResult::ForkDetected(chain_transition))
-  }
+        let light_client_mmr = contract_data_engine.checkpointed_block_tree.read().await;
+        let bitcoin_mmr = bitcoin_data_engine.indexed_mmr.read().await;
+
+        let light_client_tip_index = light_client_mmr.get_leaf_count().await.map_err(|e| {
+            ForkWatchtowerError::ForkDetectionError(format!(
+                "Failed to get light client leaf count: {}",
+                e
+            ))
+        })? - 1;
+
+        let light_client_tip_leaf = light_client_mmr
+            .get_leaf_by_leaf_index(light_client_tip_index)
+            .await
+            .map_err(|e| {
+                ForkWatchtowerError::ForkDetectionError(format!(
+                    "Failed to get light client tip leaf: {}",
+                    e
+                ))
+            })?
+            .ok_or_else(|| {
+                ForkWatchtowerError::ForkDetectionError(
+                    "Light client tip leaf not found".to_string(),
+                )
+            })?;
+
+        let bitcoin_tip_index = bitcoin_mmr.get_leaf_count().await.map_err(|e| {
+            ForkWatchtowerError::ForkDetectionError(format!(
+                "Failed to get bitcoin leaf count: {}",
+                e
+            ))
+        })? - 1;
+
+        let bitcoin_tip_leaf = bitcoin_mmr
+            .get_leaf_by_leaf_index(bitcoin_tip_index)
+            .await
+            .map_err(|e| {
+                ForkWatchtowerError::ForkDetectionError(format!(
+                    "Failed to get bitcoin tip leaf: {}",
+                    e
+                ))
+            })?
+            .ok_or_else(|| {
+                ForkWatchtowerError::ForkDetectionError("Bitcoin tip leaf not found".to_string())
+            })?;
+
+        if light_client_tip_leaf.block_hash == bitcoin_tip_leaf.block_hash {
+            info!(
+                message = "No fork tips match exactly",
+                tip_hash = hex::encode(light_client_tip_leaf.block_hash),
+            );
+            return Ok(ForkDetectionResult::NoFork);
+        }
+
+        let light_client_chainwork = light_client_tip_leaf.chainwork_as_u256();
+        let bitcoin_chainwork = bitcoin_tip_leaf.chainwork_as_u256();
+
+        if light_client_chainwork == bitcoin_chainwork {
+            info!(
+                message = "Tips have equal so first seen policy (no fork)",
+                chainwork = format!("{:x}", light_client_chainwork),
+            );
+            return Ok(ForkDetectionResult::NoFork);
+        }
+
+        let is_included =
+            Self::check_leaf_inclusion_in_bde(&light_client_tip_leaf, &bitcoin_mmr, btc_rpc)
+                .await?;
+
+        if is_included {
+            info!(
+                message = "Light client tip is included in BDE chain, no fork",
+                light_client_tip = hex::encode(light_client_tip_leaf.block_hash),
+            );
+            return Ok(ForkDetectionResult::StaleChain);
+        }
+
+        if light_client_chainwork > bitcoin_chainwork {
+            info!(
+                message =
+                    "Fork detected light client has block not in BDE chain with higher chainwork",
+                light_client_tip = hex::encode(light_client_tip_leaf.block_hash),
+                light_client_chainwork = format!("{:x}", light_client_chainwork),
+                bitcoin_chainwork = format!("{:x}", bitcoin_chainwork),
+            );
+        } else {
+            info!(
+                message =
+                    "Fork detected light client tip not in BDE chain and BDE has more chainwork",
+                light_client_tip = hex::encode(light_client_tip_leaf.block_hash),
+                light_client_chainwork = format!("{:x}", light_client_chainwork),
+                bitcoin_chainwork = format!("{:x}", bitcoin_chainwork),
+            );
+        }
+
+        let chain_transition = build_chain_transition_for_light_client_update(
+            Arc::clone(btc_rpc),
+            &bitcoin_mmr,
+            &light_client_mmr,
+            bitcoin_concurrency_limit,
+        )
+        .await
+        .map_err(|e| ForkWatchtowerError::ChainTransitionBuildError(e.to_string()))?;
+
+        Ok(ForkDetectionResult::ForkDetected(chain_transition))
+    }
 
     pub async fn check_leaf_inclusion_in_bde(
         leaf: &BlockLeaf,
@@ -616,7 +554,7 @@ impl ForkWatchtower {
             )?)
             .await;
 
-        match block_header_result { 
+        match block_header_result {
             Ok(header_info) => {
                 let block_height = header_info.height as u32;
 
@@ -624,9 +562,9 @@ impl ForkWatchtower {
                     header_info.confirmations > 0 && block_height == leaf.height;
 
                 info!(
-                  "Block found in Bitcoin chain: confirmations={}, chain height={}, block height={}, expected height={}",
-                  header_info.confirmations, block_height, block_height, leaf.height
-              );
+                    "Block found in Bitcoin chain: confirmations={}, chain height={}, block height={}, expected height={}",
+                    header_info.confirmations, block_height, block_height, leaf.height
+                );
 
                 if is_in_main_chain {
                     if let Ok(height_hash) = btc_rpc.get_block_hash(block_height as u64).await {
@@ -638,18 +576,18 @@ impl ForkWatchtower {
 
                         if height_hash_str != block_hash_str {
                             info!(
-                              "Found different block at height {} in main chain Fork detected Main chain hash: {}, Block hash: {}",
-                              block_height, height_hash_str, block_hash_str
-                          );
+                                "Found different block at height {} in main chain Fork detected Main chain hash: {}, Block hash: {}",
+                                block_height, height_hash_str, block_hash_str
+                            );
                             is_in_main_chain = false;
                         }
                     }
                 }
 
                 info!(
-                  "Block check result: is_in_main_chain={}, confirmations={}, height={}, expected_height={}",
-                  is_in_main_chain, header_info.confirmations, block_height, leaf.height
-              );
+                    "Block check result: is_in_main_chain={}, confirmations={}, height={}, expected_height={}",
+                    is_in_main_chain, header_info.confirmations, block_height, leaf.height
+                );
 
                 Ok(is_in_main_chain)
             }
@@ -709,45 +647,51 @@ impl ForkWatchtower {
 
     pub fn handle_transaction_revert(
         revert_info: &RevertInfo,
-        expected_mmr_root: [u8; 32],
     ) -> bool {
         info!(
             "Analyzing transaction revert: {:?}, debug command: {}",
             revert_info.error_payload, revert_info.debug_cli_command
         );
 
-        let error_msg = revert_info.error_payload.message.to_lowercase();
+        if let Some(data_raw) = &revert_info.error_payload.data {
+            let data_str = data_raw.to_string();
+            info!("data_str: {:?}", data_str);
+            // Remove quotes and 0x prefix, format -> "0x..."
+            let hex_str = &data_str[3..data_str.len() - 1];
+            info!("hex_str: {:?}", hex_str);
+            if let Ok(data) = hex::decode(hex_str) {
+                // Matching with Error Selector
+                // /// The error selector: `keccak256(SIGNATURE)[0..4]`
+                // const SELECTOR: [u8; 4];
+                if data.len() >= 4 {
+                    let selector = &data[0..4];
+                    info!("selector: {:?}", selector);
+                    info!(
+                        "code for Checkpoint not established: {:?}",
+                        CheckpointNotEstablished::SELECTOR
+                    );
+                    info!(
+                        "code for Chainwork too low: {:?}",
+                        ChainworkTooLow::SELECTOR
+                    );
 
-        if error_msg.contains("root already exists") || error_msg.contains("mmr root match") {
-            info!("MMR root already updated by someone else, no retry needed");
-            return false;
+                    if selector == CheckpointNotEstablished::SELECTOR {
+                        info!("Checkpoint not established");
+                        // Dont retry if check not established
+                        return false;
+                    }
+
+                    if selector == ChainworkTooLow::SELECTOR {
+                        info!("Chainwork too low");
+                        // Dont retry if chainwork is too low
+                        // The fork watchtower will automatically try again when it detects the next update
+                        return false;
+                    }
+                }
+            }
         }
 
-        if error_msg.contains("nonce too low")
-            || error_msg.contains("nonce too high")
-            || error_msg.contains("replacement transaction underpriced")
-        {
-            info!("Transaction nonce issue, will retry");
-            return true;
-        }
-
-        if error_msg.contains("gas price")
-            || error_msg.contains("max fee")
-            || error_msg.contains("gas limit")
-        {
-            info!("Gas price issue, will retry");
-            return true;
-        }
-
-        if error_msg.contains("network")
-            || error_msg.contains("timeout")
-            || error_msg.contains("connection")
-        {
-            info!("Network issue, will retry");
-            return true;
-        }
-
-        info!("Unknown revert reason, will attempt retry");
-        true
+        info!("Unknown revert reason, will not attempt retry");
+        false
     }
 }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -41,3 +41,4 @@ serial_test = { workspace = true }
 once_cell = { workspace = true }
 test-data-utils = { workspace = true }
 crypto-bigint = { workspace = true }
+mockall = "0.13.1"

--- a/integration-tests/src/hypernode_test.rs
+++ b/integration-tests/src/hypernode_test.rs
@@ -371,3 +371,927 @@ async fn test_hypernode_simple_swap() {
     // stop the hypernode
     hypernode_handle.abort();
 }
+
+#[cfg(test)]
+mod fork_watchtower_tests {
+    use crate::test_utils::{create_deposit, setup_test_tracing, MultichainAccount};
+    use alloy::providers::{DynProvider, ProviderBuilder, WsConnect};
+    use alloy::rpc::json_rpc::ErrorPayload;
+    use bitcoin_light_client_core::hasher::Keccak256Hasher;
+    use bitcoin_light_client_core::leaves::BlockLeaf;
+    use bitcoincore_rpc_async::RpcApi;
+    use crypto_bigint::{CheckedAdd, Encoding};
+    use hypernode::fork_watchtower::{ForkDetectionResult, ForkWatchtower};
+    use hypernode::{HypernodeArgs, Provider};
+    use rift_sdk::proof_generator::ProofGeneratorType;
+    use rift_sdk::DatabaseLocation;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use tokio::time::timeout;
+
+    use alloy::primitives::FixedBytes;
+    use alloy::rpc::types::{Transaction, TransactionReceipt, TransactionRequest};
+    use hypernode::txn_broadcast::{
+        PreflightCheck, RevertInfo, TransactionExecutionResult, TransactionStatusUpdate,
+    };
+    use rift_core::giga::{RiftProgramInput, RustProofType};
+    use sol_bindings::{BlockProofParams, RiftExchangeHarnessInstance};
+    use tokio::sync::broadcast;
+
+    /// Tests that the fork watchtower correctly identifies when there is no fork
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_fork_watchtower_no_fork_detection() {
+        setup_test_tracing();
+
+        let (devnet, rift_exchange, _, maker, transaction_broadcaster) = create_deposit(true).await;
+
+        let btc_rpc = devnet.bitcoin.rpc_client.clone();
+        let bitcoin_data_engine = devnet.bitcoin.data_engine.clone();
+        let contract_data_engine = devnet.contract_data_engine.clone();
+
+        // Detect fork
+        let detection_result =
+            ForkWatchtower::detect_fork(&contract_data_engine, &bitcoin_data_engine, &btc_rpc, 100)
+                .await
+                .expect("Fork detection failed");
+
+        // Verify result is NoFork
+        match detection_result {
+            ForkDetectionResult::NoFork => {
+                println!("Successfully detected no fork");
+            }
+            other => {
+                panic!("Expected NoFork, got {:?}", other);
+            }
+        }
+    }
+
+    /// Tests that the fork watchtower correctly identifies a stale chain
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_fork_watchtower_stale_chain_detection() {
+        setup_test_tracing();
+
+        let (mut devnet, rift_exchange, _, maker, transaction_broadcaster) =
+            create_deposit(true).await;
+
+        let bitcoin_height = devnet.bitcoin.rpc_client.get_block_count().await.unwrap();
+        println!("Initial Bitcoin height: {}", bitcoin_height);
+
+        let btc_rpc = devnet.bitcoin.rpc_client.clone();
+        let bitcoin_data_engine = devnet.bitcoin.data_engine.clone();
+        let contract_data_engine = devnet.contract_data_engine.clone();
+
+        // Force the light client to be stale by mining blocks but keeping the light client at the old height and ensuring its still a valid subchain
+        let initial_mmr_root = contract_data_engine.get_mmr_root().await.unwrap();
+        println!(
+            "Initial light client MMR root: {}",
+            hex::encode(initial_mmr_root)
+        );
+
+        devnet
+            .bitcoin
+            .mine_blocks(3)
+            .await
+            .expect("Failed to mine blocks");
+
+        // Wait for the bde to sync the new blocks
+        let mut block_subscription = devnet.bitcoin.data_engine.subscribe_to_new_blocks();
+        let timeout_duration = Duration::from_secs(20);
+
+        let blocks_result = timeout(timeout_duration, async {
+            for i in 0..3 {
+                if let Ok(block) = block_subscription.recv().await {
+                    println!(
+                        "Received block #{}: height={}, hash={}",
+                        i + 1,
+                        block.height,
+                        hex::encode(block.block_hash)
+                    );
+                }
+            }
+        })
+        .await;
+
+        if blocks_result.is_err() {
+            println!("Warning: Timed out waiting for blocks, continuing with test");
+        }
+
+        let detection_result =
+            ForkWatchtower::detect_fork(&contract_data_engine, &bitcoin_data_engine, &btc_rpc, 100)
+                .await
+                .expect("Fork detection after mining failed");
+
+        // Check we got stale chain
+        match detection_result {
+            ForkDetectionResult::StaleChain => {
+                println!("Successfully detected stale chain");
+
+                // Verify the light client tip is still included in the bde chain
+                let light_client_tip_index = contract_data_engine
+                    .checkpointed_block_tree
+                    .read()
+                    .await
+                    .get_leaf_count()
+                    .await
+                    .unwrap()
+                    - 1;
+                let light_client_tip = contract_data_engine
+                    .checkpointed_block_tree
+                    .read()
+                    .await
+                    .get_leaf_by_leaf_index(light_client_tip_index)
+                    .await
+                    .unwrap()
+                    .unwrap();
+
+                let bitcoin_mmr = bitcoin_data_engine.indexed_mmr.read().await;
+
+                let is_included = ForkWatchtower::check_leaf_inclusion_in_bde(
+                    &light_client_tip,
+                    &bitcoin_mmr,
+                    &btc_rpc,
+                )
+                .await
+                .expect("Leaf inclusion check failed");
+
+                assert!(
+                    is_included,
+                    "Light client tip should be included in BDE chain"
+                );
+            }
+            other => {
+                panic!("Expected StaleChain, got {:?}", other);
+            }
+        }
+    }
+
+    /// Tests that the fork watchtower correctly handles error conditions
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_fork_watchtower_error_handling() {
+        setup_test_tracing();
+
+        let (devnet, rift_exchange, _, maker, transaction_broadcaster) = create_deposit(true).await;
+
+        let btc_rpc = devnet.bitcoin.rpc_client.clone();
+        let bitcoin_data_engine = devnet.bitcoin.data_engine.clone();
+        let contract_data_engine = devnet.contract_data_engine.clone();
+
+        let mmr_root = [0u8; 32];
+
+        // Test with a revert indicating MMR root already exists
+        let already_exists_revert = hypernode::txn_broadcast::RevertInfo {
+            error_payload: ErrorPayload {
+                code: 100, //error code for MMR root already exists
+                message: "execution reverted: MMR root already exists"
+                    .to_string()
+                    .into(),
+                data: None,
+            },
+            debug_cli_command: "cast...".to_string(),
+        };
+
+        let should_retry =
+            ForkWatchtower::handle_transaction_revert(&already_exists_revert, mmr_root);
+        assert!(
+            !should_retry,
+            "Should not retry when MMR root already exists"
+        );
+
+        // Test with a nonce error
+        let nonce_revert = hypernode::txn_broadcast::RevertInfo {
+            error_payload: ErrorPayload {
+                code: 200, //nonce error code
+                message: "nonce too low".to_string().into(),
+                data: None,
+            },
+            debug_cli_command: "cast...".to_string(),
+        };
+
+        let should_retry = ForkWatchtower::handle_transaction_revert(&nonce_revert, mmr_root);
+        assert!(should_retry, "Should retry when nonce is too low");
+
+        // Test with a gas price error
+        let gas_revert = hypernode::txn_broadcast::RevertInfo {
+            error_payload: ErrorPayload {
+                code: 300, //replace with actual error for gas price
+                message: "gas price too low".to_string().into(),
+                data: None,
+            },
+            debug_cli_command: "cast...".to_string(),
+        };
+
+        let should_retry = ForkWatchtower::handle_transaction_revert(&gas_revert, mmr_root);
+        assert!(should_retry, "Should retry when gas price is too low");
+
+        // Test with a network error
+        let network_revert = hypernode::txn_broadcast::RevertInfo {
+            error_payload: ErrorPayload {
+                code: 400, //network error code
+                message: "network connection failed".to_string().into(),
+                data: None,
+            },
+            debug_cli_command: "cast...".to_string(),
+        };
+
+        let should_retry = ForkWatchtower::handle_transaction_revert(&network_revert, mmr_root);
+        assert!(should_retry, "Should retry when network connection fails");
+    }
+
+    /// Tests that the fork watchtower correctly detects and resolves a simulated fork
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_fork_watchtower_fork_detection_and_resolution() {
+        setup_test_tracing();
+
+        let (mut devnet, rift_exchange, _, maker, transaction_broadcaster) =
+            create_deposit(true).await;
+
+        let btc_rpc = devnet.bitcoin.rpc_client.clone();
+        let bitcoin_data_engine = devnet.bitcoin.data_engine.clone();
+        let contract_data_engine = devnet.contract_data_engine.clone();
+
+        // Make sure both chains are in sync meaning no fork
+        let initial_result =
+            ForkWatchtower::detect_fork(&contract_data_engine, &bitcoin_data_engine, &btc_rpc, 100)
+                .await
+                .expect("Initial fork detection failed");
+
+        match initial_result {
+            ForkDetectionResult::NoFork => {
+                println!("Successfully verified initial state has no fork");
+            }
+            other => {
+                panic!("Expected NoFork in initial state, got {:?}", other);
+            }
+        }
+
+        println!("Creating a simulated fork by mining Bitcoin blocks");
+        devnet
+            .bitcoin
+            .mine_blocks(5)
+            .await
+            .expect("Failed to mine blocks");
+
+        // Wait for the Bitcoin data engine to sync the new blocks
+        let mut block_subscription = bitcoin_data_engine.subscribe_to_new_blocks();
+        let mut blocks_seen = 0;
+        let timeout_duration = Duration::from_secs(30);
+
+        let blocks_result = timeout(timeout_duration, async {
+            while blocks_seen < 5 {
+                if let Ok(block) = block_subscription.recv().await {
+                    blocks_seen += 1;
+                    println!("Received block at height {}", block.height);
+                }
+            }
+        })
+        .await;
+
+        if blocks_result.is_err() {
+            println!("Warning: Timed out waiting for all blocks, continuing with test");
+        }
+
+        let light_client_tip_index = contract_data_engine
+            .checkpointed_block_tree
+            .read()
+            .await
+            .get_leaf_count()
+            .await
+            .unwrap()
+            - 1;
+
+        let current_light_client_tip = contract_data_engine
+            .checkpointed_block_tree
+            .read()
+            .await
+            .get_leaf_by_leaf_index(light_client_tip_index)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let bitcoin_tip_index = bitcoin_data_engine
+            .indexed_mmr
+            .read()
+            .await
+            .get_leaf_count()
+            .await
+            .unwrap()
+            - 1;
+
+        let bitcoin_tip = bitcoin_data_engine
+            .indexed_mmr
+            .read()
+            .await
+            .get_leaf_by_leaf_index(bitcoin_tip_index)
+            .await
+            .unwrap()
+            .unwrap();
+
+        println!(
+            "Current light client tip: height={}, hash={}",
+            current_light_client_tip.height,
+            hex::encode(current_light_client_tip.block_hash)
+        );
+
+        println!(
+            "Current bitcoin tip: height={}, hash={}",
+            bitcoin_tip.height,
+            hex::encode(bitcoin_tip.block_hash)
+        );
+
+        // Create a fake block with a invalid hash
+        let fake_block_hash = [0xFF; 32];
+
+        let mut chainwork = current_light_client_tip.chainwork_as_u256();
+
+        let one = crypto_bigint::U256::from_u8(1);
+        let fake_chainwork = chainwork.checked_add(&one).unwrap();
+
+        // Make sure the height is higher than current tip
+        let fake_block_leaf = BlockLeaf {
+            block_hash: fake_block_hash,
+            height: current_light_client_tip.height + 1,
+            cumulative_chainwork: fake_chainwork.to_be_bytes(),
+        };
+
+        println!(
+            "Created fake block: height={}, hash={}",
+            fake_block_leaf.height,
+            hex::encode(fake_block_leaf.block_hash)
+        );
+
+        // append the fake block to the lc chain
+        {
+            let mut checkpointed_block_tree =
+                contract_data_engine.checkpointed_block_tree.write().await;
+
+            let root = checkpointed_block_tree.get_root().await.unwrap();
+
+            println!(
+                "Light client MMR root before adding fake block: {}",
+                hex::encode(root)
+            );
+
+            checkpointed_block_tree
+                .update_from_checkpoint(&root, &[fake_block_leaf])
+                .await
+                .expect("Failed to update light client with fake block");
+
+            let new_root = checkpointed_block_tree.get_root().await.unwrap();
+
+            println!(
+                "Light client MMR root after adding fake block: {}",
+                hex::encode(new_root)
+            );
+
+            // Update the cde root cache with the new root
+            drop(checkpointed_block_tree);
+
+            contract_data_engine
+                .update_mmr_root(new_root)
+                .await
+                .unwrap();
+        }
+
+        let updated_light_client_tip_index = contract_data_engine
+            .checkpointed_block_tree
+            .read()
+            .await
+            .get_leaf_count()
+            .await
+            .unwrap()
+            - 1;
+
+        let updated_light_client_tip = contract_data_engine
+            .checkpointed_block_tree
+            .read()
+            .await
+            .get_leaf_by_leaf_index(updated_light_client_tip_index)
+            .await
+            .unwrap()
+            .unwrap();
+
+        println!(
+            "Updated light client tip: height={}, hash={}",
+            updated_light_client_tip.height,
+            hex::encode(updated_light_client_tip.block_hash)
+        );
+
+        assert_eq!(
+            updated_light_client_tip.block_hash, fake_block_hash,
+            "Light client tip should be the fake block"
+        );
+
+        {
+            let bitcoin_mmr = bitcoin_data_engine.indexed_mmr.read().await;
+            let is_included = ForkWatchtower::check_leaf_inclusion_in_bde(
+                &updated_light_client_tip,
+                &bitcoin_mmr,
+                &btc_rpc,
+            )
+            .await
+            .expect("Failed to check leaf inclusion");
+
+            println!("Is fake block included in BDE chain? {}", is_included);
+
+            assert!(
+                !is_included,
+                "Fake block should not be included in BDE chain"
+            );
+        }
+
+        // detect the fork
+        println!("Detecting fork after mining blocks");
+        let detection_result =
+            ForkWatchtower::detect_fork(&contract_data_engine, &bitcoin_data_engine, &btc_rpc, 100)
+                .await
+                .expect("Fork detection after mining failed");
+
+        println!("Fork detection result: {:?}", detection_result);
+
+        match detection_result {
+            ForkDetectionResult::ForkDetected(chain_transition) => {
+                println!("Successfully detected fork");
+
+                assert!(
+                    chain_transition.new_headers.len() > 0,
+                    "Chain transition should have new headers"
+                );
+                assert_eq!(
+                    chain_transition.current_mmr_root,
+                    contract_data_engine.get_mmr_root().await.unwrap(),
+                    "Chain transition current_mmr_root should match contract data engine root"
+                );
+
+                let fake_block_hash_in_keccak = fake_block_leaf.hash::<Keccak256Hasher>();
+                let contains_fake_hash = chain_transition
+                    .disposed_leaf_hashes
+                    .iter()
+                    .any(|hash| *hash == fake_block_hash_in_keccak);
+
+                assert!(
+                    contains_fake_hash,
+                    "Disposed leaf hashes should include the fake block"
+                );
+
+                // Get the initial state
+                let initial_light_client_mmr_root =
+                    contract_data_engine.get_mmr_root().await.unwrap();
+                let bde_mmr_root = bitcoin_data_engine
+                    .indexed_mmr
+                    .read()
+                    .await
+                    .get_root()
+                    .await
+                    .unwrap();
+
+                println!(
+                    "Initial light client MMR root: {}",
+                    hex::encode(initial_light_client_mmr_root)
+                );
+                println!("Initial BDE MMR root: {}", hex::encode(bde_mmr_root));
+
+                // Get all leaves from BDE
+                let bde_leaf_count = bitcoin_data_engine
+                    .indexed_mmr
+                    .read()
+                    .await
+                    .get_leaf_count()
+                    .await
+                    .unwrap();
+
+                let mut bde_leaves = Vec::with_capacity(bde_leaf_count);
+                for i in 0..bde_leaf_count {
+                    if let Some(leaf) = bitcoin_data_engine
+                        .indexed_mmr
+                        .read()
+                        .await
+                        .get_leaf_by_leaf_index(i)
+                        .await
+                        .unwrap()
+                    {
+                        bde_leaves.push(leaf);
+                    }
+                }
+
+                println!("Simulating fork resolution by replacing light client chain");
+
+                contract_data_engine
+                    .reset_mmr_for_testing(&bde_leaves)
+                    .await
+                    .expect("Failed to reset light client MMR");
+
+                let final_light_client_mmr_root =
+                    contract_data_engine.get_mmr_root().await.unwrap();
+
+                println!(
+                    "Final light client MMR root: {}",
+                    hex::encode(final_light_client_mmr_root)
+                );
+                println!("Final BDE MMR root: {}", hex::encode(bde_mmr_root));
+
+                assert_eq!(
+                    final_light_client_mmr_root, bde_mmr_root,
+                    "Light client MMR root should match BDE MMR root after fork resolution"
+                );
+
+                let mut found_fake_block = false;
+                let current_leaf_count = contract_data_engine
+                    .checkpointed_block_tree
+                    .read()
+                    .await
+                    .get_leaf_count()
+                    .await
+                    .unwrap();
+
+                for i in 0..current_leaf_count {
+                    let leaf_opt = contract_data_engine
+                        .checkpointed_block_tree
+                        .read()
+                        .await
+                        .get_leaf_by_leaf_index(i)
+                        .await
+                        .unwrap();
+
+                    if let Some(leaf) = leaf_opt {
+                        if leaf.block_hash == fake_block_hash {
+                            found_fake_block = true;
+                            break;
+                        }
+                    }
+                }
+
+                assert!(
+                    !found_fake_block,
+                    "Fake block should have been removed from the light client chain"
+                );
+
+                println!(
+                    "Successfully verified fake block has been removed from light client chain"
+                );
+            }
+            other => {
+                panic!("Expected ForkDetected, got {:?}", other);
+            }
+        }
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_fork_watchtower_light_client_tip_not_in_bde() {
+        setup_test_tracing();
+
+        let (mut devnet, rift_exchange, _, maker, transaction_broadcaster) =
+            create_deposit(true).await;
+
+        let btc_rpc = devnet.bitcoin.rpc_client.clone();
+        let bitcoin_data_engine = devnet.bitcoin.data_engine.clone();
+        let contract_data_engine = devnet.contract_data_engine.clone();
+
+        // make sure both chains are in sync so no fork
+        let initial_result =
+            ForkWatchtower::detect_fork(&contract_data_engine, &bitcoin_data_engine, &btc_rpc, 100)
+                .await
+                .expect("Initial fork detection failed");
+
+        match initial_result {
+            ForkDetectionResult::NoFork => {
+                println!("Successfully verified initial state has no fork");
+            }
+            other => {
+                panic!("Expected NoFork in initial state, got {:?}", other);
+            }
+        }
+
+        // Mine a block in Bitcoin chain and wait for the BDE to catch up so that the real chain is ahead of the light client
+        println!("Mining 3 blocks to advance the Bitcoin chain");
+        devnet
+            .bitcoin
+            .mine_blocks(3)
+            .await
+            .expect("Failed to mine initial blocks");
+
+        // Wait for BDE to sync
+        let mut block_subscription = bitcoin_data_engine.subscribe_to_new_blocks();
+        for _ in 0..3 {
+            let _ = block_subscription.recv().await;
+        }
+
+        // Create divergent chain
+
+        let light_client_tip_index = contract_data_engine
+            .checkpointed_block_tree
+            .read()
+            .await
+            .get_leaf_count()
+            .await
+            .unwrap()
+            - 1;
+
+        let current_light_client_tip = contract_data_engine
+            .checkpointed_block_tree
+            .read()
+            .await
+            .get_leaf_by_leaf_index(light_client_tip_index)
+            .await
+            .unwrap()
+            .unwrap();
+
+        println!(
+            "Current light client tip: height={}, hash={}",
+            current_light_client_tip.height,
+            hex::encode(current_light_client_tip.block_hash)
+        );
+
+        let bitcoin_tip_index = bitcoin_data_engine
+            .indexed_mmr
+            .read()
+            .await
+            .get_leaf_count()
+            .await
+            .unwrap()
+            - 1;
+
+        let bitcoin_tip = bitcoin_data_engine
+            .indexed_mmr
+            .read()
+            .await
+            .get_leaf_by_leaf_index(bitcoin_tip_index)
+            .await
+            .unwrap()
+            .unwrap();
+
+        println!(
+            "Current BDE tip: height={}, hash={}",
+            bitcoin_tip.height,
+            hex::encode(bitcoin_tip.block_hash)
+        );
+
+        // Create a fake block leaf that doesnt exist in the BDE chain
+        let fake_block_hash = [0x42; 32];
+        let fake_chainwork = current_light_client_tip.chainwork_as_u256();
+        let fake_block_leaf = BlockLeaf {
+            block_hash: fake_block_hash,
+            height: current_light_client_tip.height + 1,
+            cumulative_chainwork: fake_chainwork.to_be_bytes(),
+        };
+
+        println!(
+            "Created fake block: height={}, hash={}",
+            fake_block_leaf.height,
+            hex::encode(fake_block_leaf.block_hash)
+        );
+
+        {
+            let mut checkpointed_block_tree =
+                contract_data_engine.checkpointed_block_tree.write().await;
+
+            let root = checkpointed_block_tree.get_root().await.unwrap();
+
+            checkpointed_block_tree
+                .update_from_checkpoint(&root, &[fake_block_leaf])
+                .await
+                .expect("Failed to update light client with fake block");
+
+            let new_root = checkpointed_block_tree.get_root().await.unwrap();
+
+            // update the cde root cache with the new root
+            drop(checkpointed_block_tree);
+
+            // Update the cde cached MMR root
+            contract_data_engine
+                .update_mmr_root(new_root)
+                .await
+                .unwrap();
+        }
+
+        // Verify the light client has been updated with fake block
+        let new_light_client_tip_index = contract_data_engine
+            .checkpointed_block_tree
+            .read()
+            .await
+            .get_leaf_count()
+            .await
+            .unwrap()
+            - 1;
+
+        let new_light_client_tip = contract_data_engine
+            .checkpointed_block_tree
+            .read()
+            .await
+            .get_leaf_by_leaf_index(new_light_client_tip_index)
+            .await
+            .unwrap()
+            .unwrap();
+
+        println!(
+            "New light client tip: height={}, hash={}",
+            new_light_client_tip.height,
+            hex::encode(new_light_client_tip.block_hash)
+        );
+
+        // Verify the light client tip has changed to fake block
+        assert_eq!(
+            new_light_client_tip.block_hash, fake_block_hash,
+            "Light client tip should be the fake block"
+        );
+
+        // use the check_leaf_inclusion_in_bde method to check the lc tip is not in bde chain
+        let bitcoin_mmr = bitcoin_data_engine.indexed_mmr.read().await;
+        let is_included = ForkWatchtower::check_leaf_inclusion_in_bde(
+            &new_light_client_tip,
+            &bitcoin_mmr,
+            &btc_rpc,
+        )
+        .await
+        .expect("Failed to check leaf inclusion");
+
+        assert!(
+            !is_included,
+            "Light client tip should not be included in BDE chain for this test"
+        );
+
+        println!("Detecting fork with light client tip not in BDE chain");
+        let detection_result =
+            ForkWatchtower::detect_fork(&contract_data_engine, &bitcoin_data_engine, &btc_rpc, 100)
+                .await
+                .expect("Fork detection failed");
+
+        // we should have a fork
+        match detection_result {
+            ForkDetectionResult::ForkDetected(chain_transition) => {
+                println!("Successfully detected fork (light client tip not in BDE chain)");
+
+                assert!(
+                    chain_transition.new_headers.len() > 0,
+                    "Chain transition should have new headers"
+                );
+                assert_eq!(
+                    chain_transition.current_mmr_root,
+                    contract_data_engine.get_mmr_root().await.unwrap(),
+                    "Chain transition current_mmr_root should match contract data engine root"
+                );
+
+                assert!(
+                    !chain_transition.disposed_leaf_hashes.is_empty(),
+                    "Chain transition should have disposed leaf hashes"
+                );
+
+                let light_client_tip_hash = new_light_client_tip.hash::<Keccak256Hasher>();
+                let contains_tip_hash = chain_transition
+                    .disposed_leaf_hashes
+                    .iter()
+                    .any(|hash| *hash == light_client_tip_hash);
+
+                assert!(
+                    contains_tip_hash,
+                    "Disposed leaf hashes should include the light client tip"
+                );
+
+                let rift_program_input = rift_core::giga::RiftProgramInput::builder()
+                    .proof_type(rift_core::giga::RustProofType::LightClientOnly)
+                    .light_client_input(chain_transition.clone())
+                    .build()
+                    .expect("Failed to build rift program input");
+
+                let (public_values, _) = rift_program_input.get_auxiliary_light_client_data();
+
+                assert_ne!(
+                    public_values.priorMmrRoot, public_values.newMmrRoot,
+                    "New MMR root should be different from prior MMR root"
+                );
+
+                assert!(
+                    public_values.tipBlockLeaf.height >= bitcoin_tip.height,
+                    "Tip block leaf height should be at least as high as Bitcoin tip height"
+                );
+            }
+            other => {
+                panic!(
+                    "Expected ForkDetected (light client tip not in BDE), got {:?}",
+                    other
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_fork_watchtower_equal_chainwork() {
+        setup_test_tracing();
+
+        let (mut devnet, rift_exchange, _, maker, transaction_broadcaster) =
+            create_deposit(true).await;
+
+        let btc_rpc = devnet.bitcoin.rpc_client.clone();
+        let bitcoin_data_engine = devnet.bitcoin.data_engine.clone();
+        let contract_data_engine = devnet.contract_data_engine.clone();
+
+        let light_client_tip_index = contract_data_engine
+            .checkpointed_block_tree
+            .read()
+            .await
+            .get_leaf_count()
+            .await
+            .unwrap()
+            - 1;
+
+        let light_client_tip = contract_data_engine
+            .checkpointed_block_tree
+            .read()
+            .await
+            .get_leaf_by_leaf_index(light_client_tip_index)
+            .await
+            .unwrap()
+            .unwrap();
+
+        println!(
+            "Light client tip: height={}, hash={}, chainwork={}",
+            light_client_tip.height,
+            hex::encode(light_client_tip.block_hash),
+            hex::encode(light_client_tip.cumulative_chainwork)
+        );
+
+        // Create a alt block with the same chainwork but a diff hash to test the first seen policy
+        let alt_block_hash = [0xAA; 32];
+        let alt_block_leaf = BlockLeaf {
+            block_hash: alt_block_hash,
+            height: light_client_tip.height + 1,
+            cumulative_chainwork: light_client_tip.cumulative_chainwork,
+        };
+
+        println!(
+            "Created alternative block with equal chainwork: height={}, hash={}, chainwork={}",
+            alt_block_leaf.height,
+            hex::encode(alt_block_leaf.block_hash),
+            hex::encode(alt_block_leaf.cumulative_chainwork)
+        );
+
+        // Update the BDE chain with the alt block
+        {
+            let mut bitcoin_mmr = bitcoin_data_engine.indexed_mmr.write().await;
+            bitcoin_mmr
+                .append(&alt_block_leaf)
+                .await
+                .expect("Failed to append alternative block to BDE");
+        }
+
+        // check to see that the BDE now has the alt block
+        let bitcoin_tip_index = bitcoin_data_engine
+            .indexed_mmr
+            .read()
+            .await
+            .get_leaf_count()
+            .await
+            .unwrap()
+            - 1;
+
+        let bitcoin_tip = bitcoin_data_engine
+            .indexed_mmr
+            .read()
+            .await
+            .get_leaf_by_leaf_index(bitcoin_tip_index)
+            .await
+            .unwrap()
+            .unwrap();
+
+        println!(
+            "BDE tip after adding alternative block: height={}, hash={}, chainwork={}",
+            bitcoin_tip.height,
+            hex::encode(bitcoin_tip.block_hash),
+            hex::encode(bitcoin_tip.cumulative_chainwork)
+        );
+
+        // Verify the BDE and light client both have blocks with equal chainwork
+        let light_client_chainwork = light_client_tip.chainwork_as_u256();
+        let bde_chainwork = bitcoin_tip.chainwork_as_u256();
+
+        assert_eq!(
+            light_client_chainwork, bde_chainwork,
+            "BDE and light client should have equal chainwork for this test"
+        );
+
+        // Run fork detection should follow first seen policy
+        println!("Detecting fork with equal chainwork blocks (first-seen policy)");
+        let detection_result =
+            ForkWatchtower::detect_fork(&contract_data_engine, &bitcoin_data_engine, &btc_rpc, 100)
+                .await
+                .expect("Fork detection failed");
+
+        match detection_result {
+            ForkDetectionResult::NoFork => {
+                println!("Successfully applied first-seen policy for equal chainwork");
+            }
+            other => {
+                panic!(
+                    "Expected NoFork with equal chainwork (first-seen policy), got {:?}",
+                    other
+                );
+            }
+        }
+    }
+}

--- a/integration-tests/src/hypernode_test.rs
+++ b/integration-tests/src/hypernode_test.rs
@@ -420,7 +420,7 @@ mod fork_watchtower_tests {
         // Verify result is NoFork
         match detection_result {
             ForkDetectionResult::NoFork => {
-                println!("Successfully detected no fork");
+                println!("detected no fork");
             }
             other => {
                 panic!("Expected NoFork, got {:?}", other);
@@ -476,7 +476,7 @@ mod fork_watchtower_tests {
         .await;
 
         if blocks_result.is_err() {
-            println!("Warning: Timed out waiting for blocks, continuing with test");
+            println!("Err from blocks_result: Timed out waiting for blocks, continue");
         }
 
         let detection_result =
@@ -487,7 +487,7 @@ mod fork_watchtower_tests {
         // Check we got stale chain
         match detection_result {
             ForkDetectionResult::StaleChain => {
-                println!("Successfully detected stale chain");
+                println!("detected stale chain");
 
                 // Verify the light client tip is still included in the bde chain
                 let light_client_tip_index = contract_data_engine
@@ -556,10 +556,7 @@ mod fork_watchtower_tests {
 
         let should_retry =
             ForkWatchtower::handle_transaction_revert(&already_exists_revert, mmr_root);
-        assert!(
-            !should_retry,
-            "Should not retry when MMR root already exists"
-        );
+        assert!(!should_retry, "Dont retry when MMR root already exists");
 
         // Test with a nonce error
         let nonce_revert = hypernode::txn_broadcast::RevertInfo {
@@ -572,7 +569,7 @@ mod fork_watchtower_tests {
         };
 
         let should_retry = ForkWatchtower::handle_transaction_revert(&nonce_revert, mmr_root);
-        assert!(should_retry, "Should retry when nonce is too low");
+        assert!(should_retry, "retry when nonce is too low");
 
         // Test with a gas price error
         let gas_revert = hypernode::txn_broadcast::RevertInfo {
@@ -585,7 +582,7 @@ mod fork_watchtower_tests {
         };
 
         let should_retry = ForkWatchtower::handle_transaction_revert(&gas_revert, mmr_root);
-        assert!(should_retry, "Should retry when gas price is too low");
+        assert!(should_retry, "retry when gas price is too low");
 
         // Test with a network error
         let network_revert = hypernode::txn_broadcast::RevertInfo {
@@ -598,7 +595,7 @@ mod fork_watchtower_tests {
         };
 
         let should_retry = ForkWatchtower::handle_transaction_revert(&network_revert, mmr_root);
-        assert!(should_retry, "Should retry when network connection fails");
+        assert!(should_retry, "retry when network connection fails");
     }
 
     /// Tests that the fork watchtower correctly detects and resolves a simulated fork
@@ -622,7 +619,7 @@ mod fork_watchtower_tests {
 
         match initial_result {
             ForkDetectionResult::NoFork => {
-                println!("Successfully verified initial state has no fork");
+                println!("verified initial state has no fork");
             }
             other => {
                 panic!("Expected NoFork in initial state, got {:?}", other);
@@ -652,7 +649,7 @@ mod fork_watchtower_tests {
         .await;
 
         if blocks_result.is_err() {
-            println!("Warning: Timed out waiting for all blocks, continuing with test");
+            println!("Err from blocks_result: Timed out waiting for all blocks, continue");
         }
 
         let light_client_tip_index = contract_data_engine
@@ -815,7 +812,7 @@ mod fork_watchtower_tests {
 
         match detection_result {
             ForkDetectionResult::ForkDetected(chain_transition) => {
-                println!("Successfully detected fork");
+                println!("detected fork");
 
                 assert!(
                     chain_transition.new_headers.len() > 0,
@@ -930,9 +927,7 @@ mod fork_watchtower_tests {
                     "Fake block should have been removed from the light client chain"
                 );
 
-                println!(
-                    "Successfully verified fake block has been removed from light client chain"
-                );
+                println!("verified fake block has been removed from light client chain");
             }
             other => {
                 panic!("Expected ForkDetected, got {:?}", other);
@@ -960,7 +955,7 @@ mod fork_watchtower_tests {
 
         match initial_result {
             ForkDetectionResult::NoFork => {
-                println!("Successfully verified initial state has no fork");
+                println!("verified initial state has no fork");
             }
             other => {
                 panic!("Expected NoFork in initial state, got {:?}", other);
@@ -968,12 +963,12 @@ mod fork_watchtower_tests {
         }
 
         // Mine a block in Bitcoin chain and wait for the BDE to catch up so that the real chain is ahead of the light client
-        println!("Mining 3 blocks to advance the Bitcoin chain");
+        println!("Mining 3 blocks");
         devnet
             .bitcoin
             .mine_blocks(3)
             .await
-            .expect("Failed to mine initial blocks");
+            .expect("Failed to mine 3 blocks");
 
         // Wait for BDE to sync
         let mut block_subscription = bitcoin_data_engine.subscribe_to_new_blocks();
@@ -1124,7 +1119,7 @@ mod fork_watchtower_tests {
         // we should have a fork
         match detection_result {
             ForkDetectionResult::ForkDetected(chain_transition) => {
-                println!("Successfully detected fork (light client tip not in BDE chain)");
+                println!("detected fork, light client tip not in BDE chain");
 
                 assert!(
                     chain_transition.new_headers.len() > 0,
@@ -1284,11 +1279,11 @@ mod fork_watchtower_tests {
 
         match detection_result {
             ForkDetectionResult::NoFork => {
-                println!("Successfully applied first-seen policy for equal chainwork");
+                println!("applied first-seen policy for equal chainwork");
             }
             other => {
                 panic!(
-                    "Expected NoFork with equal chainwork (first-seen policy), got {:?}",
+                    "Expected NoFork with equal chainwork, first seen policy, got {:?}",
                     other
                 );
             }


### PR DESCRIPTION
Created the fork watchtower, which is responsible for basically monitoring and resolving bitcoin forks between the local bitcoin state and the on-chain LC client

The responsibilities of this new watchtower:
-Detect when the Bitcoin light client state has forked from the actual Bitcoin blockchain
-Gen zk proofs when forks are detected
-Submit txns to update the on-chain LC state
-Manage transaction retries and confirmations

So there are 4 event types: 
-NewTip (when a new Bitcoin block is detected)
-TransactionStatus (updates when txns are submitted
-CheckForFork (trigger to check for fork)
-MmrRootUpdated (MMR root updates)

Events are collected from:
-new blocks from BitcoinDataEngine
-txns status updates from TransactionBroadcaster
-MMR root updates from ContractDataEngine

Each of these sources forwards events
The main event loop processes these events and deals with them appropriately

When triggered to check for forks, we will:
-Compare the local light client state with the Bitcoin blockchain
-When it detects a fork, it generates a ZK proof
-broadcasts a transaction to update the on-chain light client state
-Track the transaction's status and implement retry logic when needed
