### PR TITLE
Fix typos in swap_watchtower.rs and README.md

### DIFF
--- a/bin/hypernode/src/swap_watchtower.rs
+++ b/bin/hypernode/src/swap_watchtower.rs
@@ -526,7 +526,7 @@ impl SwapWatchtower {
                         }
                         _ => {
                             return Err(eyre::eyre!(
-                                "Catastrphic unknown revert error submitting swap proof: {:?}",
+                                "Catastrophic unknown revert error submitting swap proof: {:?}",
                                 &revert
                             ));
                         }

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -27,7 +27,7 @@ forge script --chain arbitrum scripts/DeployRiftExchange.s.sol:DeployRiftExchang
 ### Development Workflow  
 *Execute all commands from the project root.*
 
-- **When contract code changes (unneccessary if only tests are updated):**  
+- **When contract code changes (unnecessary if only tests are updated):**  
   ```bash
   make sync
   ```


### PR DESCRIPTION


## Description

This PR fixes minor typos in the codebase:

### Changes Made

- **`bin/hypernode/src/swap_watchtower.rs`**: Fixed typo in error message
  - `"Catastrphic"` → `"Catastrophic"`
  
- **`contracts/README.md`**: Fixed typo in documentation
  - `"unneccessary"` → `"unnecessary"`

